### PR TITLE
Fix optimistic AC setpoint echo (write Temperature, not RoomTemp/RoomTempFloat)

### DIFF
--- a/ECODAN_Bridge.ino
+++ b/ECODAN_Bridge.ino
@@ -1565,11 +1565,12 @@ void MQTTonData(char* topic, byte* payload, unsigned int length) {
         DEBUG_PRINTLN("SetTempSetpoint");
         AC.SetTempSetpoint(doc["SetTempSetpoint"], AC.Status.tempMode);
 
-        // Optimistic HA
-        if (AC.Status.tempMode) {
-          AC.Status.RoomTemp = (AC.lookupByteMapIndex(AC.TEMP_MAP, 16, doc["SetTempSetpoint"]), AC.Status.tempMode);
+        // Optimistic HA - echo the new setpoint immediately (mirrors SetpointTemp in the AC status report).
+        // Setpoint lives in AC.Status.Temperature (from Process0x02), gated by tempMode - not RoomTemp/RoomTempFloat (current temp).
+        if (!AC.Status.tempMode) {
+          AC.Status.Temperature = AC.lookupByteMapIndex(AC.TEMP_MAP, 16, doc["SetTempSetpoint"]);
         } else {
-          AC.Status.RoomTempFloat = ((doc["SetTempSetpoint"].as<float>() * 2) + 128);
+          AC.Status.Temperature = doc["SetTempSetpoint"].as<float>();
         }
       }
       if (doc["SetRemoteTemp"].is<float>()) {


### PR DESCRIPTION
### Problem

Changing an AC's target temperature from Home Assistant doesn't reflect on the tile/entity for ~10s — you have to reopen the entity to see whether the change took, which feels unresponsive.

HA's MQTT climate entity is non-optimistic because a temperature state topic (`temp_stat_t`) is defined, so it only shows the new setpoint once the bridge echoes it back on `Status/AC`. The bridge already publishes immediately after a command (`PublishAllACReports()` at the end of the AC command handler in `MQTTonData()`), and already does optimistic updates for mode/fan/vane/power — but the **setpoint** optimistic update was broken, so nothing correct was published until the next full read (~10s later).

### Root cause

In `MQTTonData()`, the `SetTempSetpoint` optimistic block wrote to `AC.Status.RoomTemp` / `AC.Status.RoomTempFloat`:

```cpp
// Optimistic HA
if (AC.Status.tempMode) {
  AC.Status.RoomTemp = (AC.lookupByteMapIndex(AC.TEMP_MAP, 16, doc["SetTempSetpoint"]), AC.Status.tempMode);
} else {
  AC.Status.RoomTempFloat = ((doc["SetTempSetpoint"].as<float>() * 2) + 128);
}
```

Two problems:

1. **Wrong field.** `RoomTemp` / `RoomTempFloat` are the **current room temperature** (decoded in `Process0x03`), not the setpoint. The setpoint is `AC.Status.Temperature` (decoded in `Process0x02`) and is serialised as `SetpointTemp` in the AC status report, gated on `tempMode`:
   ```cpp
   if (!AC.Status.tempMode) {
     doc[F("SetpointTemp")] = AC.lookupByteMapValue(AC.TEMP_MAP, AC.TEMP, 16, AC.Status.Temperature);
   } else {
     doc[F("SetpointTemp")] = AC.Status.Temperature;
   }
   ```
2. **Comma operator.** The `tempMode` branch `(lookupByteMapIndex(...), AC.Status.tempMode)` evaluates to `AC.Status.tempMode` (0/1), so it assigned a boolean rather than the looked-up value.

Net effect: the setpoint never echoed optimistically (so HA showed the old value until the next read ~10s later), **and** the current-temperature reading was briefly corrupted (it received the setpoint write).

### Fix

Write `AC.Status.Temperature`, mirroring the `SetpointTemp` serialisation exactly (byte-map index when `!tempMode`, raw float when `tempMode`):

```cpp
// Optimistic HA - echo the new setpoint immediately (mirrors SetpointTemp in the AC status report).
// Setpoint lives in AC.Status.Temperature (from Process0x02), gated by tempMode - not RoomTemp/RoomTempFloat (current temp).
if (!AC.Status.tempMode) {
  AC.Status.Temperature = AC.lookupByteMapIndex(AC.TEMP_MAP, 16, doc["SetTempSetpoint"]);
} else {
  AC.Status.Temperature = doc["SetTempSetpoint"].as<float>();
}
```

The existing `PublishAllACReports()` then echoes the commanded setpoint on `Status/AC` immediately; the next real read still reconciles it if the unit clamped/rejected the value.

### Verified on hardware

M5Stack AtomS3 (Gen2), firmware **v7.0.25_EN**, built from this branch and OTA-flashed. MQTT capture of `Status/AC` while changing the target temperature:

```
CMD    SetTempSetpoint=20.0           t=0
STATUS SetpointTemp=20  RoomTemp=25   t=+0.084s     <-- previously: old value until the ~10s read
```

- Setpoint now echoes in **~84 ms** (previously ~10 s).
- `RoomTemp` (current temperature) stays correct throughout (previously briefly corrupted by the bug).

### Environment

ESP32 M5Stack AtomS3 CN105 bridge on Mitsubishi A2A units, Home Assistant MQTT climate via auto-discovery, Mosquitto broker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
