### PR TITLE
Fix AC optimistic setpoint echo regression (restore #63)

### DIFF
--- a/ECODAN_Bridge.ino
+++ b/ECODAN_Bridge.ino
@@ -1582,9 +1582,10 @@ void MQTTonData(char* topic, byte* payload, unsigned int length) {
         DEBUG_PRINTLN("SetTempSetpoint");
         AC.SetTempSetpoint(doc["SetTempSetpoint"], AC.Status.tempMode);
 
-        // Optimistic HA
-        if (AC.Status.tempMode) {
-          AC.Status.Temperature = (AC.lookupByteMapIndex(AC.TEMP_MAP, 16, doc["SetTempSetpoint"]), AC.Status.tempMode);
+        // Optimistic HA - echo the new setpoint immediately (mirrors SetpointTemp in the AC status report).
+        // Temperature holds a TEMP_MAP index when !tempMode and a raw degC float when tempMode.
+        if (!AC.Status.tempMode) {
+          AC.Status.Temperature = AC.lookupByteMapIndex(AC.TEMP_MAP, 16, doc["SetTempSetpoint"]);
         } else {
           AC.Status.Temperature = doc["SetTempSetpoint"].as<float>();
         }


### PR DESCRIPTION
Fixes #65.

### Problem

The AC optimistic setpoint echo merged in #63 was reverted by fddd488 ("Adds Polish to Languages") and shipped in v7.0.26/v7.0.27: the tempMode branches came back inverted and the comma-operator bug returned, with `AC.Status.Temperature` as the target field.

Observed on hardware (v7.0.27_EN, Gen2 / M5Stack AtomS3) — the immediate `Status/AC` echo after a setpoint command publishes `SetpointTemp: 1` (the tempMode bool via the comma operator):

```
[ 0.01s] CMD  ASHP/<mac>/Command/AC = {"SetTempSetpoint": 22.0}
[ 0.07s] STAT SetpointTemp=1  RoomTemp=23   <-- immediate echo, bogus value
[36.31s] STAT SetpointTemp=21              <-- next periodic status, real value
```

HA's discovery `temp_stat_tpl` rejects the out-of-range value and falls back to `22`, so the climate card shows a wrong/stale setpoint until the next periodic status (~30s). On `!tempMode` units the block instead stores a raw °C float where the serialiser expects a TEMP_MAP index, so the echo is wrong there too.

### Fix

Restore the #63 logic, mirroring the `SetpointTemp` serialisation exactly (TEMP_MAP index when `!tempMode`, raw float when `tempMode`):

```cpp
if (!AC.Status.tempMode) {
  AC.Status.Temperature = AC.lookupByteMapIndex(AC.TEMP_MAP, 16, doc["SetTempSetpoint"]);
} else {
  AC.Status.Temperature = doc["SetTempSetpoint"].as<float>();
}
```

The equivalent block in the Mitsubishi-CN105-Protocol-Decode copy (ported there in 3780adca) needs the same correction.

### Verification

- v7.0.25 + the original #63 fix was verified on hardware (~84ms correct echo, capture in #63).
- This branch builds clean for Gen2 (ESP32-S3) with arduino-cli; will re-verify the echo on both of my units and report back on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
