### PR TITLE
Guard optimistic AC writes against stale read-backs (~1s flicker after commands)

### DIFF
--- a/ACDecoder.cpp
+++ b/ACDecoder.cpp
@@ -1,4 +1,5 @@
 #include "ACDecoder.h"
+#include <Arduino.h>
 #include <cstdio>
 #include <ESPTelnet.h>
 extern ESPTelnet TelnetServer;
@@ -184,6 +185,26 @@ void ACDECODER::WriteOK(uint8_t *Buffer, ACStatus *Status) {
 
 
 
+// Optimistic-write reconcile guard: after MQTTonData writes a commanded value into
+// ACStatus, a read cycle already in flight can return the pre-write value and would
+// briefly publish stale state. Hold the commanded value until the unit reads it back
+// (clears the hold) or AC_PENDING_HOLD_MS lapses (unit clamped/rejected - accept truth).
+static bool holdPending(uint8_t decoded, uint8_t pending, unsigned long *until) {
+  if (*until == 0) return false;
+  if (decoded == pending) { *until = 0; return false; }  // unit confirmed the write
+  if ((long)(millis() - *until) < 0) return true;        // still settling - hold commanded value
+  *until = 0;                                            // window lapsed - accept the unit's value
+  return false;
+}
+
+static bool holdPendingFloat(float decoded, float pending, unsigned long *until) {
+  if (*until == 0) return false;
+  if (decoded == pending) { *until = 0; return false; }
+  if ((long)(millis() - *until) < 0) return true;
+  *until = 0;
+  return false;
+}
+
 void ACDECODER::Process0x02(uint8_t *Buffer, ACStatus *Status) {
   for (int i = 1; i < 16; i++) {
     Array0x02[i] = Buffer[i];
@@ -192,21 +213,37 @@ void ACDECODER::Process0x02(uint8_t *Buffer, ACStatus *Status) {
   //fc, 62, 01, 30, 10, 02, 00, 00, 01, 03, 0d, 00, 00, 00, 00, 85, a4, 46, 00, 00, 00, db,
   //                                [3] [4][5]                 [10][11][12]
 
-  Status->SystemPowerMode = Buffer[3];             // Power
-  Status->isee = Buffer[4] > 0x08 ? true : false;  // Op Mode
-  Status->Buffer04 = Buffer[4];                    // Op Mode
+  if (!holdPending(Buffer[3], Status->PendingPower, &Status->PendingPowerUntil)) {
+    Status->SystemPowerMode = Buffer[3];  // Power
+  }
+  // Mode compares i-See-normalised base codes; isee and Buffer04 are held as a pair
+  // so the report's (Buffer04 - 0x08 when isee) decode stays consistent.
+  if (!holdPending(Buffer[4] > 0x08 ? Buffer[4] - 0x08 : Buffer[4], Status->PendingMode, &Status->PendingModeUntil)) {
+    Status->isee = Buffer[4] > 0x08 ? true : false;  // Op Mode
+    Status->Buffer04 = Buffer[4];                    // Op Mode
+  }
   //Status->legacyTargetTemp = Buffer[5];               // Legacy Target Temperature
-  Status->fan = Buffer[6];             // Fan Speed
-  Status->vane = Buffer[7];            // Vertical Vane
+  if (!holdPending(Buffer[6], Status->PendingFan, &Status->PendingFanUntil)) {
+    Status->fan = Buffer[6];  // Fan Speed
+  }
+  if (!holdPending(Buffer[7], Status->PendingVane, &Status->PendingVaneUntil)) {
+    Status->vane = Buffer[7];  // Vertical Vane
+  }
   Status->remoteProhibit = Buffer[8];  // Remote Prohibit
-  Status->wideVane = Buffer[10];       // Horizonal Vane
-  if (Buffer[11] != 0x00) {            // Target Temperature
+  if (!holdPending(Buffer[10] & 0x0F, Status->PendingWideVane & 0x0F, &Status->PendingWideVaneUntil)) {
+    Status->wideVane = Buffer[10];  // Horizonal Vane
+  }
+  if (Buffer[11] != 0x00) {  // Target Temperature
     int temp = Buffer[11];
     temp -= 128;
-    Status->Temperature = (float)temp / 2;
-    Status->tempMode = true;  // FloatMode
+    if (!holdPendingFloat((float)temp / 2, Status->PendingTemperature, &Status->PendingTempUntil)) {
+      Status->Temperature = (float)temp / 2;
+      Status->tempMode = true;  // FloatMode
+    }
   } else {
-    Status->Temperature = Buffer[5];
+    if (!holdPendingFloat((float)Buffer[5], Status->PendingTemperature, &Status->PendingTempUntil)) {
+      Status->Temperature = Buffer[5];
+    }
   }
   //Buffer[12];                                         // (UNCONFIRMED) Target Humidity
   //Buffer[13];                                         // (UNCONFIRMED) Power Saving Mode

--- a/ACDecoder.h
+++ b/ACDecoder.h
@@ -22,6 +22,8 @@
 #define HEADERSIZE 5
 #define MAXDATABLOCKSIZE 16
 
+#define AC_PENDING_HOLD_MS 5000  // How long an optimistic write shields a field from stale read-backs
+
 #define PREAMBLESIZE 2
 
 
@@ -46,6 +48,14 @@ typedef struct _ACStatus {
   uint8_t SystemPowerMode, fan, vane, remoteProhibit, wideVane, Buffer04;
   float Temperature;
   bool tempMode, isee;
+
+  // Optimistic-write reconcile guard: last commanded values, held until the unit
+  // reads them back or the hold window lapses (see holdPending in ACDecoder.cpp).
+  // Pending*Until == 0 means no hold is active for that field.
+  uint8_t PendingPower = 0, PendingMode = 0, PendingFan = 0, PendingVane = 0, PendingWideVane = 0;
+  float PendingTemperature = 0;
+  unsigned long PendingPowerUntil = 0, PendingModeUntil = 0, PendingFanUntil = 0,
+    PendingVaneUntil = 0, PendingWideVaneUntil = 0, PendingTempUntil = 0;
 
   // From Message 0x03
   float OAT, RoomTempFloat;

--- a/ECODAN_Bridge.ino
+++ b/ECODAN_Bridge.ino
@@ -1558,26 +1558,36 @@ void MQTTonData(char* topic, byte* payload, unsigned int length) {
         bool systempower = doc["systempower"];
         AC.SetSystemPowerMode(systempower);
         AC.Status.SystemPowerMode = systempower ? 0x01 : 0x00;  // Optimistic HA
+        AC.Status.PendingPower = AC.Status.SystemPowerMode;
+        AC.Status.PendingPowerUntil = millis() + AC_PENDING_HOLD_MS;
       }
       if (doc["SetMode"].is<const char*>()) {
         DEBUG_PRINTLN("SetMode");
         AC.SetMode(doc["SetMode"]);
-        AC.Status.Buffer04 = AC.MODE[AC.lookupByteMapIndex(AC.MODE_MAP, 5, doc["SetMode"])];  // Optimistic HA
+        AC.Status.PendingMode = AC.MODE[AC.lookupByteMapIndex(AC.MODE_MAP, 5, doc["SetMode"])];
+        AC.Status.Buffer04 = AC.Status.isee ? AC.Status.PendingMode + 0x08 : AC.Status.PendingMode;  // Optimistic HA (keep the i-See offset the report decode expects)
+        AC.Status.PendingModeUntil = millis() + AC_PENDING_HOLD_MS;
       }
       if (doc["SetFanSpeed"].is<const char*>()) {
         DEBUG_PRINTLN("SetFan");
         AC.SetFanSpeed(doc["SetFanSpeed"]);
         AC.Status.fan = AC.FAN[AC.lookupByteMapIndex(AC.FAN_MAP, 6, doc["SetFanSpeed"])];  // Optimistic HA
+        AC.Status.PendingFan = AC.Status.fan;
+        AC.Status.PendingFanUntil = millis() + AC_PENDING_HOLD_MS;
       }
       if (doc["SetVane"].is<const char*>()) {
         DEBUG_PRINTLN("SetVane");
         AC.SetVane(doc["SetVane"]);
         AC.Status.vane = AC.VANE[AC.lookupByteMapIndex(AC.VANE_MAP, 7, doc["SetVane"])];  // Optimistic HA
+        AC.Status.PendingVane = AC.Status.vane;
+        AC.Status.PendingVaneUntil = millis() + AC_PENDING_HOLD_MS;
       }
       if (doc["SetWideVane"].is<const char*>()) {
         DEBUG_PRINTLN("SetWideVane");
         AC.SetWideVane(doc["SetWideVane"]);
         AC.Status.wideVane = AC.WIDEVANE[AC.lookupByteMapIndex(AC.WIDEVANE_MAP, 7, doc["SetWideVane"])];  // Optimistic HA
+        AC.Status.PendingWideVane = AC.Status.wideVane;
+        AC.Status.PendingWideVaneUntil = millis() + AC_PENDING_HOLD_MS;
       }
       if (doc["SetTempSetpoint"].is<float>()) {
         DEBUG_PRINTLN("SetTempSetpoint");
@@ -1589,6 +1599,8 @@ void MQTTonData(char* topic, byte* payload, unsigned int length) {
         } else {
           AC.Status.Temperature = doc["SetTempSetpoint"].as<float>();
         }
+        AC.Status.PendingTemperature = AC.Status.Temperature;
+        AC.Status.PendingTempUntil = millis() + AC_PENDING_HOLD_MS;
       }
       if (doc["SetRemoteTemp"].is<float>()) {
         DEBUG_PRINTLN("SetRemoteTemp");


### PR DESCRIPTION
### Problem

The AC command handler in `MQTTonData()` does optimistic writes into `AC.Status` (power, mode, fan, vane, wideVane, setpoint) and publishes immediately — but a status read cycle that is already in flight when the command lands can decode the **pre-write** value and publish it on the next `PublishAllACReports()`, briefly reverting the entity in HA (~1s flicker) until the following cycle reconciles.

Capture from v7.0.27_EN (Gen2 / AtomS3, setpoint changed 22→23 from HA):

```
[41.29s] CMD  {"SetTempSetpoint": 23.0}
[41.33s] STAT SetpointTemp=23     <-- optimistic echo, correct
[41.94s] STAT SetpointTemp=22     <-- in-flight read cycle publishes the stale value
[~2s   ] STAT SetpointTemp=23     <-- next cycle reconciles
```

The same race applies to every optimistically-written field (power/mode/fan/vane/wideVane).

### Fix

A small reconcile guard: each optimistic write records its commanded value and arms a per-field hold window (`AC_PENDING_HOLD_MS`, 5s). In `Process0x02`, a guarded field only accepts the decoded value if (a) no hold is active, (b) the decoded value matches the commanded one (unit confirmed — hold cleared), or (c) the window has lapsed (unit clamped/rejected the write — the unit's real state wins). So the behaviour stays self-healing; stale read-backs just can't overwrite a write that is still settling.

Details:

- Per-field windows are independent — commanding the fan doesn't shield the mode.
- Mode is compared on i-See-normalised base codes, and `isee`/`Buffer04` are held as a pair so the report's `(Buffer04 - 0x08 when isee)` decode stays consistent. The optimistic mode write now also preserves the i-See offset (previously it wrote the base code over an i-See-offset value, which broke the mode report on i-See units until the next read).
- wideVane compares on the low nibble, matching the report's `& 0x0F`.
- Non-commanded fields (`remoteProhibit`, everything from 0x03/0x04/0x05/0x06/0x09) decode unguarded as before.

### Verified on hardware

Two Gen2/AtomS3 units on Mitsubishi A2A, this branch on the v7.0.28 base. Setpoint, mode, and power commands: every `Status/AC` publish between the command and the unit's confirmation carried the commanded value — across multiple full read cycles — with zero reversion, and the hold cleared on the unit's confirmation within one cycle. (The 5s lapse path for clamped/rejected writes is by design; not separately exercised on hardware.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
